### PR TITLE
Rearrange app navigation

### DIFF
--- a/project/src/App.tsx
+++ b/project/src/App.tsx
@@ -45,21 +45,23 @@ function App() {
 
   const getTabTitle = () => {
     switch (activeTab) {
-      case 'feed': return 'Today';
-      case 'capture': return 'Capture';
-      case 'stories': return 'Stories';
-      case 'achievements': return 'Progress';
-      case 'profile': return 'Profile';
-      default: return 'Rewind';
+      case 'feed':
+        return 'Today';
+      case 'profile':
+        return 'Profile';
+      default:
+        return 'Rewind';
     }
   };
 
   const getTabSubtitle = () => {
     switch (activeTab) {
-      case 'feed': return 'Your memory timeline';
-      case 'achievements': return 'Your journey so far';
-      case 'profile': return `${mockUser.streakDays} day streak`;
-      default: return undefined;
+      case 'feed':
+        return 'Your memory timeline';
+      case 'profile':
+        return `${mockUser.streakDays} day streak`;
+      default:
+        return undefined;
     }
   };
 
@@ -70,14 +72,36 @@ function App() {
       <div className="max-w-md mx-auto px-4 py-6">
         {activeTab === 'feed' && (
           <div className="space-y-6">
-            <DailyPrompt 
+            <DailyPrompt
               prompt={todayPrompt}
               timeLeft={timeLeft}
               onSubmit={handlePromptSubmit}
             />
-            
+
+            <div className="bg-white rounded-2xl p-6 text-center shadow-sm border border-gray-100">
+              <div className="w-16 h-16 bg-primary-100 rounded-full flex items-center justify-center mx-auto mb-4">
+                <span className="text-3xl">📸</span>
+              </div>
+              <h3 className="text-lg font-semibold text-gray-900 mb-2">Capture Mode</h3>
+              <p className="text-gray-600 mb-4">Quick capture for spontaneous memories</p>
+              <button className="bg-primary-600 text-white px-4 py-2 rounded-xl font-medium hover:bg-primary-700 transition-colors">
+                Start Capturing
+              </button>
+            </div>
+
+            <div className="bg-white rounded-2xl p-6 text-center shadow-sm border border-gray-100">
+              <div className="w-16 h-16 bg-blue-100 rounded-full flex items-center justify-center mx-auto mb-4">
+                <span className="text-3xl">🎤</span>
+              </div>
+              <h3 className="text-lg font-semibold text-gray-900 mb-2">Voice Stories</h3>
+              <p className="text-gray-600 mb-4">Share your stories through voice</p>
+              <button className="bg-blue-600 text-white px-4 py-2 rounded-xl font-medium hover:bg-blue-700 transition-colors">
+                Browse Stories
+              </button>
+            </div>
+
             <FriendsLeaderboard friends={mockFriends} />
-            
+
             <div>
               <h3 className="text-lg font-semibold text-gray-900 mb-4">Your Memories</h3>
               <div className="space-y-4">
@@ -89,44 +113,21 @@ function App() {
           </div>
         )}
 
-        {activeTab === 'capture' && (
-          <div className="text-center py-20">
-            <div className="w-32 h-32 bg-primary-100 rounded-full flex items-center justify-center mx-auto mb-6">
-              <span className="text-4xl">📸</span>
-            </div>
-            <h2 className="text-xl font-semibold text-gray-900 mb-2">Capture Mode</h2>
-            <p className="text-gray-600 mb-8">Quick capture for spontaneous memories</p>
-            <button className="bg-primary-600 text-white px-8 py-3 rounded-2xl font-medium hover:bg-primary-700 transition-colors">
-              Start Capturing
-            </button>
-          </div>
-        )}
 
-        {activeTab === 'stories' && (
-          <div className="text-center py-20">
-            <div className="w-32 h-32 bg-blue-100 rounded-full flex items-center justify-center mx-auto mb-6">
-              <span className="text-4xl">🎤</span>
-            </div>
-            <h2 className="text-xl font-semibold text-gray-900 mb-2">Voice Stories</h2>
-            <p className="text-gray-600 mb-8">Share your stories through voice</p>
-            <button className="bg-blue-600 text-white px-8 py-3 rounded-2xl font-medium hover:bg-blue-700 transition-colors">
-              Browse Stories
-            </button>
-          </div>
-        )}
-
-        {activeTab === 'achievements' && (
-          <div className="space-y-4">
-            {mockAchievements.map(achievement => (
-              <AchievementCard key={achievement.id} achievement={achievement} />
-            ))}
-          </div>
-        )}
 
         {activeTab === 'profile' && (
           <div className="space-y-6">
             <ProfileStats user={mockUser} />
-            
+
+            <div>
+              <h3 className="text-lg font-semibold text-gray-900 mb-4">Progress</h3>
+              <div className="space-y-4">
+                {mockAchievements.map((achievement) => (
+                  <AchievementCard key={achievement.id} achievement={achievement} />
+                ))}
+              </div>
+            </div>
+
             <div className="bg-white rounded-2xl p-6 shadow-sm border border-gray-100">
               <h3 className="text-lg font-semibold text-gray-900 mb-4">Settings</h3>
               <div className="space-y-3">

--- a/project/src/components/TabBar.tsx
+++ b/project/src/components/TabBar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Home, Camera, User, Trophy, MessageCircle } from 'lucide-react';
+import { Home, User } from 'lucide-react';
 
 interface TabBarProps {
   activeTab: string;
@@ -9,9 +9,6 @@ interface TabBarProps {
 export default function TabBar({ activeTab, onTabChange }: TabBarProps) {
   const tabs = [
     { id: 'feed', icon: Home, label: 'Feed' },
-    { id: 'capture', icon: Camera, label: 'Capture' },
-    { id: 'stories', icon: MessageCircle, label: 'Stories' },
-    { id: 'achievements', icon: Trophy, label: 'Progress' },
     { id: 'profile', icon: User, label: 'Profile' },
   ];
 


### PR DESCRIPTION
## Summary
- integrate capture mode and stories into feed screen
- move achievement progress to the profile
- simplify tab bar to just feed and profile

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6850871f7ff88332b98ad76d0b1d84c5