### PR TITLE
Integrate Firebase for profiles and memories

### DIFF
--- a/project/src/App.tsx
+++ b/project/src/App.tsx
@@ -26,6 +26,10 @@ function App() {
   const [user, setUser] = useState<FirebaseUser | null>(null);
   const [userProfile, setUserProfile] = useState<User | null>(null);
 
+  const handleAvatarUpdated = (url: string) => {
+    setUserProfile(prev => (prev ? { ...prev, avatar: url } : prev));
+  };
+
   useEffect(() => {
     if (!user) return;
     const unsubUser = onSnapshot(doc(db, 'users', user.uid), (snap) => {
@@ -175,7 +179,9 @@ function App() {
 
         {activeTab === 'profile' && (
           <div className="space-y-6">
-            {userProfile && <ProfileStats user={userProfile} />}
+            {userProfile && (
+              <ProfileStats user={userProfile} onAvatarChange={handleAvatarUpdated} />
+            )}
 
             <div>
               <h3 className="text-lg font-semibold text-gray-900 mb-4">Progress</h3>

--- a/project/src/components/ProfileStats.tsx
+++ b/project/src/components/ProfileStats.tsx
@@ -8,9 +8,10 @@ import { doc, updateDoc } from 'firebase/firestore';
 
 interface ProfileStatsProps {
   user: User;
+  onAvatarChange?: (url: string) => void;
 }
 
-export default function ProfileStats({ user }: ProfileStatsProps) {
+export default function ProfileStats({ user, onAvatarChange }: ProfileStatsProps) {
   const joinDays = Math.floor((new Date().getTime() - user.joinDate.getTime()) / (1000 * 60 * 60 * 24));
 
   const handleAvatarChange = async (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -21,6 +22,7 @@ export default function ProfileStats({ user }: ProfileStatsProps) {
     const url = await getDownloadURL(avatarRef);
     await updateProfile(auth.currentUser, { photoURL: url });
     await updateDoc(doc(db, 'users', auth.currentUser.uid), { avatar: url });
+    onAvatarChange?.(url);
   };
 
   return (

--- a/project/src/data/mockData.ts
+++ b/project/src/data/mockData.ts
@@ -1,14 +1,4 @@
-import { Memory, Friend, Achievement, User } from '../types';
-
-export const mockUser: User = {
-  id: '1',
-  name: 'Alex Chen',
-  username: 'alexc',
-  avatar: 'https://images.pexels.com/photos/1043471/pexels-photo-1043471.jpeg?w=150&h=150&fit=crop&crop=face',
-  streakDays: 23,
-  totalMemories: 156,
-  joinDate: new Date('2024-01-15'),
-};
+import { Memory, Friend, Achievement } from '../types';
 
 export const mockMemories: Memory[] = [
   {

--- a/project/src/firebase.ts
+++ b/project/src/firebase.ts
@@ -1,5 +1,7 @@
 import { initializeApp } from 'firebase/app';
 import { getAuth } from 'firebase/auth';
+import { getFirestore } from 'firebase/firestore';
+import { getStorage } from 'firebase/storage';
 
 const firebaseConfig = {
   apiKey: "AIzaSyAoeLl6IuaPaKXDSla6QC2Rc3cxAPvNWvs",
@@ -12,3 +14,5 @@ const firebaseConfig = {
 
 const app = initializeApp(firebaseConfig);
 export const auth = getAuth(app);
+export const db = getFirestore(app);
+export const storage = getStorage(app);


### PR DESCRIPTION
## Summary
- extend Firebase setup to include Firestore and Storage
- allow choosing a username during sign‑up and create Firestore profile
- persist memories to Firestore and display the authenticated user's streak
- let users change their avatar which uploads to Firebase Storage
- drop the mock user data

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68515b88c9ec83328b56cdaa54815ab0