### PR TITLE
Add Expo mobile app

### DIFF
--- a/mobile/App.tsx
+++ b/mobile/App.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { View, ScrollView, StyleSheet } from 'react-native';
+import { StatusBar } from 'expo-status-bar';
+import MemoryCard from './components/MemoryCard';
+import { mockMemories } from './data/mockData';
+
+export default function App() {
+  return (
+    <View style={styles.container}>
+      <ScrollView contentContainerStyle={styles.content}>
+        {mockMemories.map((m) => (
+          <MemoryCard key={m.id} memory={m} />
+        ))}
+      </ScrollView>
+      <StatusBar style="auto" />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#f0f0f0',
+  },
+  content: {
+    padding: 16,
+  },
+});

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -1,0 +1,10 @@
+{
+  "expo": {
+    "name": "RewindMobile",
+    "slug": "rewind-mobile",
+    "version": "1.0.0",
+    "sdkVersion": "50.0.0",
+    "platforms": ["ios", "android", "web"],
+    "entryPoint": "./App.tsx"
+  }
+}

--- a/mobile/components/MemoryCard.tsx
+++ b/mobile/components/MemoryCard.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { Memory } from '../types';
+
+interface Props {
+  memory: Memory;
+}
+
+export default function MemoryCard({ memory }: Props) {
+  return (
+    <View style={styles.card}>
+      {memory.prompt && (
+        <View style={styles.promptBox}>
+          <Text style={styles.promptText}>&quot;{memory.prompt}&quot;</Text>
+        </View>
+      )}
+      <Text style={styles.content}>{memory.content}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    backgroundColor: '#fff',
+    borderRadius: 12,
+    padding: 16,
+    marginBottom: 12,
+  },
+  promptBox: {
+    backgroundColor: '#f3f3f3',
+    padding: 8,
+    borderRadius: 8,
+    marginBottom: 8,
+  },
+  promptText: {
+    fontStyle: 'italic',
+    color: '#555',
+  },
+  content: {
+    color: '#333',
+  },
+});

--- a/mobile/data/mockData.ts
+++ b/mobile/data/mockData.ts
@@ -1,0 +1,139 @@
+import { Memory, Friend, Achievement, User } from '../types';
+
+export const mockUser: User = {
+  id: '1',
+  name: 'Alex Chen',
+  username: 'alexc',
+  avatar: 'https://images.pexels.com/photos/1043471/pexels-photo-1043471.jpeg?w=150&h=150&fit=crop&crop=face',
+  streakDays: 23,
+  totalMemories: 156,
+  joinDate: new Date('2024-01-15'),
+};
+
+export const mockMemories: Memory[] = [
+  {
+    id: '1',
+    content: 'Had an amazing coffee chat with Sarah about the new project. Feeling inspired and ready to tackle the challenges ahead!',
+    timestamp: new Date(Date.now() - 2 * 60 * 60 * 1000),
+    type: 'text',
+    prompt: 'What\'s making you feel grateful today?',
+    location: 'Blue Bottle Coffee',
+    mood: 'Excited',
+  },
+  {
+    id: '2',
+    content: 'Voice note about morning run',
+    timestamp: new Date(Date.now() - 5 * 60 * 60 * 1000),
+    type: 'voice',
+    prompt: 'How are you taking care of yourself today?',
+    location: 'Golden Gate Park',
+    mood: 'Energized',
+  },
+  {
+    id: '3',
+    content: 'Beautiful sunset from the rooftop',
+    timestamp: new Date(Date.now() - 24 * 60 * 60 * 1000),
+    type: 'photo',
+    isLate: true,
+    location: 'Home',
+    mood: 'Peaceful',
+  },
+  {
+    id: '4',
+    content: 'Finally finished reading "Atomic Habits". The compound effect of small changes is mind-blowing. Time to implement what I learned!',
+    timestamp: new Date(Date.now() - 2 * 24 * 60 * 60 * 1000),
+    type: 'text',
+    prompt: 'What did you learn today?',
+    mood: 'Accomplished',
+  },
+];
+
+export const mockFriends: Friend[] = [
+  {
+    id: '1',
+    name: 'Sarah Johnson',
+    username: 'sarahj',
+    avatar: 'https://images.pexels.com/photos/1239291/pexels-photo-1239291.jpeg?w=150&h=150&fit=crop&crop=face',
+    hoursSpent: 142,
+  },
+  {
+    id: '2',
+    name: 'Mike Chen',
+    username: 'mikec',
+    avatar: 'https://images.pexels.com/photos/1222271/pexels-photo-1222271.jpeg?w=150&h=150&fit=crop&crop=face',
+    hoursSpent: 98,
+  },
+  {
+    id: '3',
+    name: 'Emma Wilson',
+    username: 'emmaw',
+    avatar: 'https://images.pexels.com/photos/1036623/pexels-photo-1036623.jpeg?w=150&h=150&fit=crop&crop=face',
+    hoursSpent: 76,
+  },
+  {
+    id: '4',
+    name: 'David Kim',
+    username: 'davidk',
+    avatar: 'https://images.pexels.com/photos/1043474/pexels-photo-1043474.jpeg?w=150&h=150&fit=crop&crop=face',
+    hoursSpent: 54,
+  },
+];
+
+export const mockAchievements: Achievement[] = [
+  {
+    id: '1',
+    title: '30-Day Streak',
+    description: 'Journal for 30 consecutive days',
+    progress: 23,
+    total: 30,
+    icon: '🔥',
+    completed: false,
+  },
+  {
+    id: '2',
+    title: 'Voice Master',
+    description: 'Record 50 voice memories',
+    progress: 50,
+    total: 50,
+    icon: '🎤',
+    completed: true,
+  },
+  {
+    id: '3',
+    title: 'Social Butterfly',
+    description: 'Spend 100 hours with friends',
+    progress: 87,
+    total: 100,
+    icon: '🦋',
+    completed: false,
+  },
+  {
+    id: '4',
+    title: 'Memory Keeper',
+    description: 'Create 200 memories',
+    progress: 156,
+    total: 200,
+    icon: '📚',
+    completed: false,
+  },
+  {
+    id: '5',
+    title: 'Early Bird',
+    description: 'Complete 20 morning prompts',
+    progress: 15,
+    total: 20,
+    icon: '🌅',
+    completed: false,
+  },
+];
+
+export const todayPrompts = [
+  "What's the vibe today?",
+  "Who are you with right now?",
+  "What are you wearing?",
+  "What's something you don't want to forget?",
+  "How are you feeling in this moment?",
+  "What's making you smile today?",
+  "Where are you and what's around you?",
+  "What's on your mind right now?",
+];

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "rewind-mobile",
+  "version": "0.0.1",
+  "private": true,
+  "main": "node_modules/expo/AppEntry.js",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
+    "web": "expo start --web"
+  },
+  "dependencies": {
+    "expo": "~50.0.0",
+    "expo-status-bar": "~1.10.0",
+    "react": "18.2.0",
+    "react-native": "0.73.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.0.0"
+  }
+}

--- a/mobile/tsconfig.json
+++ b/mobile/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "jsx": "react",
+    "moduleResolution": "node",
+    "target": "es2017",
+    "lib": ["es2017"],
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}

--- a/mobile/types/index.ts
+++ b/mobile/types/index.ts
@@ -1,0 +1,38 @@
+export interface Memory {
+  id: string;
+  content: string;
+  timestamp: Date;
+  type: 'text' | 'voice' | 'photo';
+  prompt?: string;
+  isLate?: boolean;
+  location?: string;
+  mood?: string;
+}
+
+export interface Friend {
+  id: string;
+  name: string;
+  username: string;
+  avatar: string;
+  hoursSpent: number;
+}
+
+export interface Achievement {
+  id: string;
+  title: string;
+  description: string;
+  progress: number;
+  total: number;
+  icon: string;
+  completed: boolean;
+}
+
+export interface User {
+  id: string;
+  name: string;
+  username: string;
+  avatar: string;
+  streakDays: number;
+  totalMemories: number;
+  joinDate: Date;
+}


### PR DESCRIPTION
## Summary
- add a `mobile` folder with a basic Expo Go app
- include minimal components and mock data for React Native

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6851ac097c5c833289cf49bdfbf8e2bd