### PR TITLE
Enable memory sharing into feed

### DIFF
--- a/RewindApp/app/(tabs)/index.tsx
+++ b/RewindApp/app/(tabs)/index.tsx
@@ -1,8 +1,9 @@
-import React, { useState, useEffect } from "react";
+import React from "react";
 import { View, Text, ScrollView, Image, TouchableOpacity, StyleSheet } from "react-native";
 import { FontAwesome5, Feather } from "@expo/vector-icons";
-import { mockMemories, mockFriends } from "../data/mockData";
+import { mockFriends } from "../data/mockData";
 import Header from "../components/Header";
+import { useMemories } from "../context/MemoriesContext";
 
 // -- MemoryCard Implementation --
 function MemoryCard({ memory }: { memory: any }) {
@@ -109,7 +110,7 @@ function MemoryCard({ memory }: { memory: any }) {
 }
 
 export default function FeedScreen() {
-  const [memories, setMemories] = useState(mockMemories);
+  const { memories } = useMemories();
 
   return (
     <ScrollView style={styles.container} contentContainerStyle={{ paddingBottom: 80 }}>

--- a/RewindApp/app/(tabs)/rewind.tsx
+++ b/RewindApp/app/(tabs)/rewind.tsx
@@ -5,6 +5,7 @@ import { todayPrompts } from "../data/mockData";
 import Header from "../components/Header";
 import { ScrollView } from "react-native";
 import { TextInput } from "react-native";
+import { useMemories } from "../context/MemoriesContext";
 
 
 // --- DailyPrompt (Mobile Version) ---
@@ -111,6 +112,7 @@ function PromptTypeButton({ icon, active, onPress, label }: any) {
 export default function RewindScreen() {
   const [timeLeft, setTimeLeft] = useState(18430);
   const [todayPrompt] = useState(todayPrompts[Math.floor(Math.random() * todayPrompts.length)]);
+  const { addMemory } = useMemories();
 
   useEffect(() => {
     const timer = setInterval(() => setTimeLeft((prev) => Math.max(0, prev - 1)), 1000);
@@ -118,9 +120,7 @@ export default function RewindScreen() {
   }, []);
 
   const handlePromptSubmit = (content: string, type: "text" | "voice" | "photo") => {
-    // You can save this in state or connect to your backend
-    // For now, just console.log
-    console.log("New memory:", { content, type });
+    addMemory({ content, type, prompt: todayPrompt });
   };
 
   return (

--- a/RewindApp/app/_layout.tsx
+++ b/RewindApp/app/_layout.tsx
@@ -2,15 +2,19 @@
 import React from "react";
 import { View, StyleSheet } from "react-native";
 import { Stack } from "expo-router";
+import { MemoriesProvider } from "../context/MemoriesContext";
+import { mockMemories } from "./data/mockData";
 
 export default function RootLayout() {
   return (
-    <View style={styles.root}>
-      <Stack screenOptions={{ headerShown: false }}>
-        <Stack.Screen name="(tabs)" />
-        <Stack.Screen name="+not-found" />
-      </Stack>
-    </View>
+    <MemoriesProvider initial={mockMemories}>
+      <View style={styles.root}>
+        <Stack screenOptions={{ headerShown: false }}>
+          <Stack.Screen name="(tabs)" />
+          <Stack.Screen name="+not-found" />
+        </Stack>
+      </View>
+    </MemoriesProvider>
   );
 }
 

--- a/RewindApp/context/MemoriesContext.tsx
+++ b/RewindApp/context/MemoriesContext.tsx
@@ -1,0 +1,34 @@
+import React, { createContext, useContext, useState } from 'react';
+import { Memory } from '../types';
+
+interface MemoriesContextValue {
+  memories: Memory[];
+  addMemory: (memory: Omit<Memory, 'id' | 'timestamp'> & { id?: string; timestamp?: Date }) => void;
+}
+
+const MemoriesContext = createContext<MemoriesContextValue | undefined>(undefined);
+
+export const MemoriesProvider = ({ children, initial }: { children: React.ReactNode; initial?: Memory[] }) => {
+  const [memories, setMemories] = useState<Memory[]>(initial ?? []);
+
+  const addMemory = (memory: Omit<Memory, 'id' | 'timestamp'> & { id?: string; timestamp?: Date }) => {
+    const newMemory: Memory = {
+      id: memory.id ?? Date.now().toString(),
+      timestamp: memory.timestamp ?? new Date(),
+      ...memory,
+    } as Memory;
+    setMemories(prev => [newMemory, ...prev]);
+  };
+
+  return (
+    <MemoriesContext.Provider value={{ memories, addMemory }}>
+      {children}
+    </MemoriesContext.Provider>
+  );
+};
+
+export const useMemories = () => {
+  const ctx = useContext(MemoriesContext);
+  if (!ctx) throw new Error('useMemories must be used within MemoriesProvider');
+  return ctx;
+};


### PR DESCRIPTION
## Summary
- create `MemoriesContext` for cross-screen memory state
- wrap navigation stack in `MemoriesProvider`
- use shared memories in feed
- add new memories from the Rewind prompt

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851dea289208332ba07e87a417e4a65