### PR TITLE
Add theme system with dark mode toggle

### DIFF
--- a/RewindApp/app/(tabs)/_layout.tsx
+++ b/RewindApp/app/(tabs)/_layout.tsx
@@ -1,19 +1,21 @@
 // (tabs)/_layout.tsx
 import { Tabs } from "expo-router";
 import { Ionicons } from "@expo/vector-icons";
+import { useTheme } from "../contexts/ThemeContext";
 
 export default function TabsLayout() {
+  const { colors } = useTheme();
   return (
     <Tabs
       screenOptions={{
         headerShown: false,
-        tabBarActiveTintColor: "#fb5607",     // Orange highlight
-        tabBarInactiveTintColor: "#6b7280",   // Gray for inactive
-        tabBarShowLabel: false,               // No text under icon
+        tabBarActiveTintColor: colors.accent,
+        tabBarInactiveTintColor: colors.secondaryText,
+        tabBarShowLabel: false,
         tabBarStyle: {
-          backgroundColor: "#fff",
+          backgroundColor: colors.card,
           borderTopWidth: 1,
-          borderTopColor: "#f3f4f6",
+          borderTopColor: colors.border,
           height: 70,
         },
         tabBarItemStyle: {

--- a/RewindApp/app/(tabs)/index.tsx
+++ b/RewindApp/app/(tabs)/index.tsx
@@ -3,6 +3,7 @@ import { View, Text, ScrollView, Image, TouchableOpacity, StyleSheet } from "rea
 import { FontAwesome5, Feather } from "@expo/vector-icons";
 import { mockMemories, mockFriends } from "../data/mockData";
 import Header from "../components/Header";
+import { useTheme } from "../contexts/ThemeContext";
 
 // -- MemoryCard Implementation --
 function MemoryCard({ memory }: { memory: any }) {
@@ -110,6 +111,8 @@ function MemoryCard({ memory }: { memory: any }) {
 
 export default function FeedScreen() {
   const [memories, setMemories] = useState(mockMemories);
+  const { colors } = useTheme();
+  const styles = React.useMemo(() => makeStyles(colors), [colors]);
 
   return (
     <ScrollView style={styles.container} contentContainerStyle={{ paddingBottom: 80 }}>
@@ -166,14 +169,14 @@ function FriendsLeaderboard({ friends }: { friends: any[] }) {
 }
 
 // --- Styles ---
-const styles = StyleSheet.create({
-  container: { flex: 1, backgroundColor: "#f9fafb", paddingHorizontal: 16, paddingTop: 32 },
-  leaderboardContainer: { backgroundColor: "#fff", borderRadius: 18, padding: 20, marginBottom: 16, shadowColor: "#000", shadowOpacity: 0.06, shadowRadius: 8, elevation: 1, borderWidth: 1, borderColor: "#f3f4f6" },
-  friendCard: { flexDirection: "row", alignItems: "center", padding: 12, backgroundColor: "#f3f4f6", borderRadius: 14, marginBottom: 8 },
+const makeStyles = (c: ReturnType<typeof useTheme>["colors"]) => StyleSheet.create({
+  container: { flex: 1, backgroundColor: c.background, paddingHorizontal: 16, paddingTop: 32 },
+  leaderboardContainer: { backgroundColor: c.card, borderRadius: 18, padding: 20, marginBottom: 16, shadowColor: "#000", shadowOpacity: 0.06, shadowRadius: 8, elevation: 1, borderWidth: 1, borderColor: c.border },
+  friendCard: { flexDirection: "row", alignItems: "center", padding: 12, backgroundColor: c.border, borderRadius: 14, marginBottom: 8 },
   avatar: { width: 40, height: 40, borderRadius: 20 },
   crownOverlay: { position: "absolute", top: -5, right: -5, backgroundColor: "#facc15", borderRadius: 10, width: 20, height: 20, alignItems: "center", justifyContent: "center" },
-  viewAllButton: { marginTop: 12, alignSelf: "stretch", alignItems: "center", paddingVertical: 10, borderRadius: 14, backgroundColor: "#f3f4f6" },
-  sectionTitle: { fontWeight: "bold", fontSize: 18, marginVertical: 10, color: "#18181b", marginLeft: 4, marginBottom: 14 },
+  viewAllButton: { marginTop: 12, alignSelf: "stretch", alignItems: "center", paddingVertical: 10, borderRadius: 14, backgroundColor: c.border },
+  sectionTitle: { fontWeight: "bold", fontSize: 18, marginVertical: 10, color: c.text, marginLeft: 4, marginBottom: 14 },
   // ---- MemoryCard Styles ----
   memoryCardOuter: {
     width: "100%",
@@ -181,7 +184,7 @@ const styles = StyleSheet.create({
     marginBottom: 20,
   },
   memoryCard: {
-    backgroundColor: "#fff",
+    backgroundColor: c.card,
     borderRadius: 16,
     padding: 18,
     shadowColor: "#000",
@@ -189,18 +192,18 @@ const styles = StyleSheet.create({
     shadowRadius: 6,
     elevation: 1,
     borderWidth: 1,
-    borderColor: "#f3f4f6",
+    borderColor: c.border,
     maxWidth: 420,
     width: "100%",
   },
-  memoryPrompt: { marginBottom: 10, padding: 10, backgroundColor: "#f3f4f6", borderRadius: 12 },
-  memoryPromptText: { fontStyle: "italic", color: "#64748b", fontSize: 14 },
+  memoryPrompt: { marginBottom: 10, padding: 10, backgroundColor: c.border, borderRadius: 12 },
+  memoryPromptText: { fontStyle: "italic", color: c.secondaryText, fontSize: 14 },
   memoryAvatar: { width: 40, height: 40, backgroundColor: "#fb923c", borderRadius: 20, alignItems: "center", justifyContent: "center", marginRight: 10 },
   lateBadge: { backgroundColor: "#ffedd5", color: "#ea580c", paddingHorizontal: 8, paddingVertical: 2, borderRadius: 999, fontSize: 12, fontWeight: "600" },
   memoryMetaRow: { flexDirection: "row", alignItems: "center", marginBottom: 8 },
   memoryMetaItem: { flexDirection: "row", alignItems: "center", marginRight: 12 },
-  memoryMetaText: { color: "#6b7280", marginLeft: 4, fontSize: 13 },
-  memoryContent: { color: "#262626", fontSize: 15, lineHeight: 22, marginTop: 2 },
+  memoryMetaText: { color: c.secondaryText, marginLeft: 4, fontSize: 13 },
+  memoryContent: { color: c.text, fontSize: 15, lineHeight: 22, marginTop: 2 },
   memoryVoiceBox: {
     backgroundColor: "#dbeafe",
     borderRadius: 12,
@@ -252,12 +255,12 @@ const styles = StyleSheet.create({
     marginBottom: 2,
   },
   memoryPhotoDescription: {
-    color: "#262626",
+    color: c.text,
     fontSize: 14,
     marginTop: 2,
     flexShrink: 1,
   },
-  memoryMoodRow: { marginTop: 14, borderTopWidth: 1, borderTopColor: "#f3f4f6", paddingTop: 8 },
-  memoryMoodText: { color: "#6b7280", fontSize: 13 },
+  memoryMoodRow: { marginTop: 14, borderTopWidth: 1, borderTopColor: c.border, paddingTop: 8 },
+  memoryMoodText: { color: c.secondaryText, fontSize: 13 },
 });
 

--- a/RewindApp/app/(tabs)/index.tsx
+++ b/RewindApp/app/(tabs)/index.tsx
@@ -7,6 +7,9 @@ import { useTheme } from "../contexts/ThemeContext";
 
 // -- MemoryCard Implementation --
 function MemoryCard({ memory }: { memory: any }) {
+  const { colors } = useTheme();
+  const styles = React.useMemo(() => makeStyles(colors), [colors]);
+
   const getTypeIcon = () => {
     switch (memory.type) {
       case "voice":
@@ -132,6 +135,8 @@ export default function FeedScreen() {
 // ----- OTHER COMPONENTS -----
 
 function FriendsLeaderboard({ friends }: { friends: any[] }) {
+  const { colors } = useTheme();
+  const styles = React.useMemo(() => makeStyles(colors), [colors]);
   return (
     <View style={styles.leaderboardContainer}>
       <View style={{ flexDirection: "row", alignItems: "center", marginBottom: 12 }}>

--- a/RewindApp/app/(tabs)/profile.tsx
+++ b/RewindApp/app/(tabs)/profile.tsx
@@ -3,9 +3,12 @@ import { View, Text, Image, ScrollView, TouchableOpacity, StyleSheet } from "rea
 import { Feather, FontAwesome5, MaterialCommunityIcons } from "@expo/vector-icons";
 import { mockUser, mockAchievements } from "../data/mockData";
 import Header from "../components/Header";
+import { useTheme } from "../contexts/ThemeContext";
 
 // Profile Stats Card
 function ProfileStats({ user }: { user: any }) {
+  const { colors } = useTheme();
+  const styles = React.useMemo(() => makeStyles(colors), [colors]);
   const joinDays = Math.floor((Date.now() - new Date(user.joinDate).getTime()) / (1000 * 60 * 60 * 24));
 
   return (
@@ -69,6 +72,8 @@ function ProfileStats({ user }: { user: any }) {
 function AchievementCard({ achievement }: { achievement: any }) {
   const progressPercentage = (achievement.progress / achievement.total) * 100;
   const completed = achievement.completed;
+  const { colors } = useTheme();
+  const styles = React.useMemo(() => makeStyles(colors), [colors]);
   return (
     <View style={[
       styles.achievementCard,
@@ -110,6 +115,8 @@ function AchievementCard({ achievement }: { achievement: any }) {
 }
 
 export default function ProfileScreen() {
+  const { colors, toggleTheme } = useTheme();
+  const styles = React.useMemo(() => makeStyles(colors), [colors]);
   return (
     <ScrollView style={styles.container} contentContainerStyle={{ paddingBottom: 80 }}>
       <Header title="Profile" subtitle={`${mockUser.streakDays} day streak`} />
@@ -129,45 +136,46 @@ export default function ProfileScreen() {
         <TouchableOpacity style={styles.settingsButton}><Text style={styles.settingsButtonText}>Notification Settings</Text></TouchableOpacity>
         <TouchableOpacity style={styles.settingsButton}><Text style={styles.settingsButtonText}>Export My Data</Text></TouchableOpacity>
         <TouchableOpacity style={styles.settingsButton}><Text style={styles.settingsButtonText}>Time Capsule</Text></TouchableOpacity>
+        <TouchableOpacity style={styles.settingsButton} onPress={toggleTheme}><Text style={styles.settingsButtonText}>Toggle Theme</Text></TouchableOpacity>
         <TouchableOpacity style={styles.settingsButton}><Text style={[styles.settingsButtonText, { color: "#ef4444" }]}>Log Out</Text></TouchableOpacity>
       </View>
     </ScrollView>
   );
 }
 
-const styles = StyleSheet.create({
-  container: { flex: 1, backgroundColor: "#f9fafb", paddingHorizontal: 16, paddingTop: 32 },
+const makeStyles = (c: ReturnType<typeof useTheme>["colors"]) => StyleSheet.create({
+  container: { flex: 1, backgroundColor: c.background, paddingHorizontal: 16, paddingTop: 32 },
 
   // Profile Card
-  profileStatsCard: { backgroundColor: "#fff", borderRadius: 20, padding: 22, marginBottom: 26, borderColor: "#f3f4f6", borderWidth: 1, shadowColor: "#000", shadowOpacity: 0.03, shadowRadius: 4, elevation: 1 },
+  profileStatsCard: { backgroundColor: c.card, borderRadius: 20, padding: 22, marginBottom: 26, borderColor: c.border, borderWidth: 1, shadowColor: "#000", shadowOpacity: 0.03, shadowRadius: 4, elevation: 1 },
   profileHeaderRow: { flexDirection: "row", alignItems: "center", marginBottom: 16 },
   profileAvatar: { width: 64, height: 64, borderRadius: 32, marginRight: 18 },
-  profileName: { fontSize: 20, fontWeight: "bold", color: "#18181b" },
-  profileUsername: { color: "#6b7280", fontSize: 14 },
+  profileName: { fontSize: 20, fontWeight: "bold", color: c.text },
+  profileUsername: { color: c.secondaryText, fontSize: 14 },
   statsGrid: { flexDirection: "row", flexWrap: "wrap", justifyContent: "space-between", marginBottom: 20 },
   statsCell: { width: "47%", borderRadius: 14, alignItems: "center", paddingVertical: 15, marginBottom: 10 },
   statsNumber: { fontSize: 22, fontWeight: "bold", marginTop: 5, marginBottom: 1 },
   statsLabel: { fontSize: 13, fontWeight: "600" },
 
   // Wrap
-  profileWrap: { marginTop: 10, borderTopColor: "#f3f4f6", borderTopWidth: 1, paddingTop: 16 },
+  profileWrap: { marginTop: 10, borderTopColor: c.border, borderTopWidth: 1, paddingTop: 16 },
   wrapHeaderRow: { flexDirection: "row", justifyContent: "space-between", marginBottom: 10 },
   wrapHeader: { fontSize: 14, fontWeight: "600", color: "#374151" },
   wrapViewAll: { color: "#6366f1", fontSize: 14, fontWeight: "600" },
   wrapRow: { flexDirection: "row", justifyContent: "space-between" },
-  wrapLabel: { color: "#64748b", fontSize: 13 },
-  wrapValue: { fontWeight: "bold", color: "#18181b", fontSize: 13 },
+  wrapLabel: { color: c.secondaryText, fontSize: 13 },
+  wrapValue: { fontWeight: "bold", color: c.text, fontSize: 13 },
 
   // Progress/Achievements
-  progressTitle: { fontWeight: "bold", fontSize: 18, marginVertical: 18, color: "#18181b" },
-  achievementCard: { backgroundColor: "#fff", borderRadius: 16, padding: 16, marginBottom: 16, borderColor: "#f3f4f6", borderWidth: 1, shadowColor: "#000", shadowOpacity: 0.03, shadowRadius: 4, elevation: 1 },
+  progressTitle: { fontWeight: "bold", fontSize: 18, marginVertical: 18, color: c.text },
+  achievementCard: { backgroundColor: c.card, borderRadius: 16, padding: 16, marginBottom: 16, borderColor: c.border, borderWidth: 1, shadowColor: "#000", shadowOpacity: 0.03, shadowRadius: 4, elevation: 1 },
   achievementIcon: { padding: 12, borderRadius: 12, marginRight: 10, alignItems: "center", justifyContent: "center" },
   achievementBarBg: { width: "100%", height: 7, backgroundColor: "#e5e7eb", borderRadius: 6, overflow: "hidden", marginTop: 4 },
   achievementBar: { height: 7, borderRadius: 6 },
 
   // Settings
-  settingsCard: { backgroundColor: "#fff", borderRadius: 20, padding: 20, marginTop: 20, borderColor: "#f3f4f6", borderWidth: 1, shadowColor: "#000", shadowOpacity: 0.03, shadowRadius: 4, elevation: 1 },
-  settingsTitle: { fontSize: 18, fontWeight: "bold", color: "#18181b", marginBottom: 10 },
-  settingsButton: { paddingVertical: 14, borderRadius: 12, marginBottom: 4, backgroundColor: "#f9fafb" },
-  settingsButtonText: { color: "#374151", fontWeight: "600", fontSize: 15 },
+  settingsCard: { backgroundColor: c.card, borderRadius: 20, padding: 20, marginTop: 20, borderColor: c.border, borderWidth: 1, shadowColor: "#000", shadowOpacity: 0.03, shadowRadius: 4, elevation: 1 },
+  settingsTitle: { fontSize: 18, fontWeight: "bold", color: c.text, marginBottom: 10 },
+  settingsButton: { paddingVertical: 14, borderRadius: 12, marginBottom: 4, backgroundColor: c.background },
+  settingsButtonText: { color: c.text, fontWeight: "600", fontSize: 15 },
 });

--- a/RewindApp/app/(tabs)/rewind.tsx
+++ b/RewindApp/app/(tabs)/rewind.tsx
@@ -5,6 +5,7 @@ import { todayPrompts } from "../data/mockData";
 import Header from "../components/Header";
 import { ScrollView } from "react-native";
 import { TextInput } from "react-native";
+import { useTheme } from "../contexts/ThemeContext";
 
 
 // --- DailyPrompt (Mobile Version) ---
@@ -12,6 +13,8 @@ function DailyPrompt({ prompt, timeLeft, onSubmit }: { prompt: string; timeLeft:
   const [inputType, setInputType] = useState<"text" | "voice" | "photo">("text");
   const [content, setContent] = useState("");
   const [isRecording, setIsRecording] = useState(false);
+  const { colors } = useTheme();
+  const styles = React.useMemo(() => makeStyles(colors), [colors]);
 
   const formatTime = (seconds: number) => {
     const hours = Math.floor(seconds / 3600);
@@ -111,6 +114,8 @@ function PromptTypeButton({ icon, active, onPress, label }: any) {
 export default function RewindScreen() {
   const [timeLeft, setTimeLeft] = useState(18430);
   const [todayPrompt] = useState(todayPrompts[Math.floor(Math.random() * todayPrompts.length)]);
+  const { colors } = useTheme();
+  const styles = React.useMemo(() => makeStyles(colors), [colors]);
 
   useEffect(() => {
     const timer = setInterval(() => setTimeLeft((prev) => Math.max(0, prev - 1)), 1000);
@@ -155,27 +160,27 @@ export default function RewindScreen() {
 
 // Simple mobile Header (optional, or use your own)
 // --- Styles ---
-const styles = StyleSheet.create({
-  container: { flex: 1, backgroundColor: "#f9fafb", paddingHorizontal: 16, paddingTop: 32 },
+const makeStyles = (c: ReturnType<typeof useTheme>["colors"]) => StyleSheet.create({
+  container: { flex: 1, backgroundColor: c.background, paddingHorizontal: 16, paddingTop: 32 },
   promptContainer: { backgroundColor: "#fff7ed", borderRadius: 18, padding: 18, marginVertical: 18, borderWidth: 1, borderColor: "#fee2b3" },
   promptHeader: { flexDirection: "row", alignItems: "center", justifyContent: "space-between", marginBottom: 12 },
   pulseDot: { width: 8, height: 8, backgroundColor: "#f59e42", borderRadius: 4, marginRight: 6 },
   promptHeaderText: { fontSize: 14, color: "#f59e42", fontWeight: "bold" },
   promptTime: { fontSize: 14, color: "#f59e42", marginLeft: 6 },
-  promptTitle: { fontSize: 16, fontWeight: "bold", color: "#18181b", marginBottom: 12 },
+  promptTitle: { fontSize: 16, fontWeight: "bold", color: c.text, marginBottom: 12 },
   inputTypeRow: { flexDirection: "row", gap: 8, marginBottom: 10 },
   promptTypeButton: { flexDirection: "row", alignItems: "center", paddingVertical: 8, paddingHorizontal: 18, borderRadius: 12, marginRight: 8 },
   textAreaContainer: { marginBottom: 10 },
-  textArea: { backgroundColor: "#fff", borderRadius: 12, borderColor: "#ddd", borderWidth: 1, padding: 12, minHeight: 60, fontSize: 15, color: "#18181b" },
+  textArea: { backgroundColor: c.card, borderRadius: 12, borderColor: c.border, borderWidth: 1, padding: 12, minHeight: 60, fontSize: 15, color: c.text },
   shareButton: { marginTop: 6, backgroundColor: "#f59e42", paddingVertical: 13, borderRadius: 12, alignItems: "center" },
   voiceButton: { marginTop: 10, width: 80, height: 80, borderRadius: 40, alignItems: "center", justifyContent: "center" },
   photoButton: { marginTop: 10, width: 80, height: 80, borderRadius: 40, backgroundColor: "#f59e42", alignItems: "center", justifyContent: "center" },
 
-  card: { backgroundColor: "#fff", borderRadius: 20, padding: 24, alignItems: "center", marginBottom: 24, shadowColor: "#000", shadowOpacity: 0.06, shadowRadius: 8, elevation: 1, borderWidth: 1, borderColor: "#f3f4f6" },
+  card: { backgroundColor: c.card, borderRadius: 20, padding: 24, alignItems: "center", marginBottom: 24, shadowColor: "#000", shadowOpacity: 0.06, shadowRadius: 8, elevation: 1, borderWidth: 1, borderColor: c.border },
   iconCircleOrange: { width: 64, height: 64, borderRadius: 32, backgroundColor: "#fed7aa", alignItems: "center", justifyContent: "center", marginBottom: 16 },
   iconCircleBlue: { width: 64, height: 64, borderRadius: 32, backgroundColor: "#dbeafe", alignItems: "center", justifyContent: "center", marginBottom: 16 },
-  cardTitle: { fontSize: 18, fontWeight: "bold", color: "#18181b", marginBottom: 6 },
-  cardSubtitle: { color: "#64748b", marginBottom: 16, fontSize: 15, textAlign: "center" },
+  cardTitle: { fontSize: 18, fontWeight: "bold", color: c.text, marginBottom: 6 },
+  cardSubtitle: { color: c.secondaryText, marginBottom: 16, fontSize: 15, textAlign: "center" },
   cardButtonOrange: { backgroundColor: "#f59e42", paddingVertical: 12, paddingHorizontal: 28, borderRadius: 14 },
   cardButtonBlue: { backgroundColor: "#3b82f6", paddingVertical: 12, paddingHorizontal: 28, borderRadius: 14 },
 });

--- a/RewindApp/app/(tabs)/rewind.tsx
+++ b/RewindApp/app/(tabs)/rewind.tsx
@@ -44,9 +44,9 @@ function DailyPrompt({ prompt, timeLeft, onSubmit }: { prompt: string; timeLeft:
       </View>
       <Text style={styles.promptTitle}>{prompt}</Text>
       <View style={styles.inputTypeRow}>
-        <PromptTypeButton icon={<Feather name="type" size={16} />} active={inputType === "text"} onPress={() => setInputType("text")} label="Text" />
-        <PromptTypeButton icon={<Feather name="mic" size={16} />} active={inputType === "voice"} onPress={() => setInputType("voice")} label="Voice" />
-        <PromptTypeButton icon={<Feather name="camera" size={16} />} active={inputType === "photo"} onPress={() => setInputType("photo")} label="Photo" />
+        <PromptTypeButton styles={styles} icon={<Feather name="type" size={16} />} active={inputType === "text"} onPress={() => setInputType("text")} label="Text" />
+        <PromptTypeButton styles={styles} icon={<Feather name="mic" size={16} />} active={inputType === "voice"} onPress={() => setInputType("voice")} label="Voice" />
+        <PromptTypeButton styles={styles} icon={<Feather name="camera" size={16} />} active={inputType === "photo"} onPress={() => setInputType("photo")} label="Photo" />
       </View>
       {inputType === "text" && (
         <View>
@@ -94,7 +94,7 @@ function DailyPrompt({ prompt, timeLeft, onSubmit }: { prompt: string; timeLeft:
   );
 }
 
-function PromptTypeButton({ icon, active, onPress, label }: any) {
+function PromptTypeButton({ styles, icon, active, onPress, label }: any) {
   return (
     <TouchableOpacity
       onPress={onPress}

--- a/RewindApp/app/_layout.tsx
+++ b/RewindApp/app/_layout.tsx
@@ -2,10 +2,12 @@
 import React from "react";
 import { View, StyleSheet } from "react-native";
 import { Stack } from "expo-router";
+import { ThemeProvider, useTheme } from "./contexts/ThemeContext";
 
-export default function RootLayout() {
+function Layout() {
+  const { colors } = useTheme();
   return (
-    <View style={styles.root}>
+    <View style={[styles.root, { backgroundColor: colors.background }]}>
       <Stack screenOptions={{ headerShown: false }}>
         <Stack.Screen name="(tabs)" />
         <Stack.Screen name="+not-found" />
@@ -14,9 +16,16 @@ export default function RootLayout() {
   );
 }
 
+export default function RootLayout() {
+  return (
+    <ThemeProvider>
+      <Layout />
+    </ThemeProvider>
+  );
+}
+
 const styles = StyleSheet.create({
   root: {
     flex: 1,
-    backgroundColor: "#f9fafb", // Off-white/light gray background
   },
 });

--- a/RewindApp/app/colors.ts
+++ b/RewindApp/app/colors.ts
@@ -1,0 +1,26 @@
+export interface ThemeColors {
+  background: string;
+  card: string;
+  text: string;
+  secondaryText: string;
+  border: string;
+  accent: string;
+}
+
+export const lightColors: ThemeColors = {
+  background: '#f9fafb',
+  card: '#ffffff',
+  text: '#18181b',
+  secondaryText: '#6b7280',
+  border: '#f3f4f6',
+  accent: '#fb5607',
+};
+
+export const darkColors: ThemeColors = {
+  background: '#1e1e1e',
+  card: '#27272a',
+  text: '#f3f4f6',
+  secondaryText: '#a1a1aa',
+  border: '#3f3f46',
+  accent: '#fb5607',
+};

--- a/RewindApp/app/components/Header.tsx
+++ b/RewindApp/app/components/Header.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { View, Text, StyleSheet, TouchableOpacity } from 'react-native';
 import { Feather } from '@expo/vector-icons';
+import { useTheme } from '../contexts/ThemeContext';
 
 interface HeaderProps {
   title: string;
@@ -8,6 +9,9 @@ interface HeaderProps {
 }
 
 export default function Header({ title, subtitle }: HeaderProps) {
+  const { colors } = useTheme();
+  const styles = React.useMemo(() => makeStyles(colors), [colors]);
+
   return (
     <View style={styles.container}>
       <View>
@@ -16,10 +20,10 @@ export default function Header({ title, subtitle }: HeaderProps) {
       </View>
       <View style={styles.actions}>
         <TouchableOpacity style={styles.iconButton}>
-          <Feather name="search" size={20} color="#4b5563" />
+          <Feather name="search" size={20} color={colors.secondaryText} />
         </TouchableOpacity>
         <TouchableOpacity style={[styles.iconButton, { position: 'relative' }]}>
-          <Feather name="bell" size={20} color="#4b5563" />
+          <Feather name="bell" size={20} color={colors.secondaryText} />
           <View style={styles.notificationDot} />
         </TouchableOpacity>
       </View>
@@ -27,42 +31,43 @@ export default function Header({ title, subtitle }: HeaderProps) {
   );
 }
 
-const styles = StyleSheet.create({
-  container: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    paddingVertical: 12,
-    paddingHorizontal: 16,
-    backgroundColor: 'fff',
-    borderBottomWidth: 1,
-    borderBottomColor: '#f3f4f6',
-  },
-  title: {
-    fontSize: 20,
-    fontWeight: 'bold',
-    color: '#111827',
-  },
-  subtitle: {
-    fontSize: 13,
-    color: '#6b7280',
-  },
-  actions: {
-    flexDirection: 'row',
-    alignItems: 'center',
-  },
-  iconButton: {
-    padding: 8,
-    borderRadius: 999,
-    marginLeft: 12,
-  },
-  notificationDot: {
-    position: 'absolute',
-    top: 2,
-    right: 2,
-    width: 6,
-    height: 6,
-    borderRadius: 3,
-    backgroundColor: '#f59e42',
-  },
-});
+const makeStyles = (c: ReturnType<typeof useTheme>["colors"]) =>
+  StyleSheet.create({
+    container: {
+      flexDirection: 'row',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      paddingVertical: 12,
+      paddingHorizontal: 16,
+      backgroundColor: c.card,
+      borderBottomWidth: 1,
+      borderBottomColor: c.border,
+    },
+    title: {
+      fontSize: 20,
+      fontWeight: 'bold',
+      color: c.text,
+    },
+    subtitle: {
+      fontSize: 13,
+      color: c.secondaryText,
+    },
+    actions: {
+      flexDirection: 'row',
+      alignItems: 'center',
+    },
+    iconButton: {
+      padding: 8,
+      borderRadius: 999,
+      marginLeft: 12,
+    },
+    notificationDot: {
+      position: 'absolute',
+      top: 2,
+      right: 2,
+      width: 6,
+      height: 6,
+      borderRadius: 3,
+      backgroundColor: c.accent,
+    },
+  });

--- a/RewindApp/app/contexts/ThemeContext.tsx
+++ b/RewindApp/app/contexts/ThemeContext.tsx
@@ -1,0 +1,34 @@
+import React, { createContext, useContext, useState } from 'react';
+import { ThemeColors, lightColors, darkColors } from '../colors';
+
+type ThemeType = 'light' | 'dark';
+
+interface ThemeContextProps {
+  theme: ThemeType;
+  colors: ThemeColors;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextProps>({
+  theme: 'light',
+  colors: lightColors,
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  toggleTheme: () => {},
+});
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setTheme] = useState<ThemeType>('light');
+  const colors = theme === 'light' ? lightColors : darkColors;
+
+  const toggleTheme = () => setTheme((prev) => (prev === 'light' ? 'dark' : 'light'));
+
+  return (
+    <ThemeContext.Provider value={{ theme, colors, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  return useContext(ThemeContext);
+}


### PR DESCRIPTION
## Summary
- add color palette and theme context
- wrap app in ThemeProvider and use theme colors
- update screens and header to pull colors from context
- allow toggling between light and dark themes via settings

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851df02e1b483329d2f773eeaf01aea