### PR TITLE
Add Firebase auth with login/signup

### DIFF
--- a/RewindApp/README.md
+++ b/RewindApp/README.md
@@ -25,6 +25,10 @@ In the output, you'll find options to open the app in a
 
 You can start developing by editing the files inside the **app** directory. This project uses [file-based routing](https://docs.expo.dev/router/introduction).
 
+## Authentication
+
+This project uses Firebase Authentication. The Firebase config is already set up in `firebase.ts`. Simply run `npm install` to install dependencies and start the app. You can create an account or log in using the provided screens.
+
 ## Get a fresh project
 
 When you're ready, run:

--- a/RewindApp/app/(tabs)/profile.tsx
+++ b/RewindApp/app/(tabs)/profile.tsx
@@ -1,5 +1,7 @@
 import React from "react";
 import { View, Text, Image, ScrollView, TouchableOpacity, StyleSheet } from "react-native";
+import { signOut } from "firebase/auth";
+import { auth } from "../firebase";
 import { Feather, FontAwesome5, MaterialCommunityIcons } from "@expo/vector-icons";
 import { mockUser, mockAchievements } from "../data/mockData";
 import Header from "../components/Header";
@@ -129,7 +131,7 @@ export default function ProfileScreen() {
         <TouchableOpacity style={styles.settingsButton}><Text style={styles.settingsButtonText}>Notification Settings</Text></TouchableOpacity>
         <TouchableOpacity style={styles.settingsButton}><Text style={styles.settingsButtonText}>Export My Data</Text></TouchableOpacity>
         <TouchableOpacity style={styles.settingsButton}><Text style={styles.settingsButtonText}>Time Capsule</Text></TouchableOpacity>
-        <TouchableOpacity style={styles.settingsButton}><Text style={[styles.settingsButtonText, { color: "#ef4444" }]}>Log Out</Text></TouchableOpacity>
+        <TouchableOpacity style={styles.settingsButton} onPress={() => signOut(auth)}><Text style={[styles.settingsButtonText, { color: "#ef4444" }]}>Log Out</Text></TouchableOpacity>
       </View>
     </ScrollView>
   );

--- a/RewindApp/app/_layout.tsx
+++ b/RewindApp/app/_layout.tsx
@@ -1,22 +1,53 @@
-// app/_layout.tsx
 import React from "react";
-import { View, StyleSheet } from "react-native";
+import { View, StyleSheet, ActivityIndicator } from "react-native";
 import { Stack } from "expo-router";
+import { AuthProvider, useAuth } from "../context/AuthContext";
 
-export default function RootLayout() {
+function Layout() {
+  const { user, loading } = useAuth();
+
+  if (loading) {
+    return (
+      <View style={[styles.root, styles.center]}>
+        <ActivityIndicator size="large" />
+      </View>
+    );
+  }
+
   return (
     <View style={styles.root}>
       <Stack screenOptions={{ headerShown: false }}>
-        <Stack.Screen name="(tabs)" />
-        <Stack.Screen name="+not-found" />
+        {user ? (
+          <>
+            <Stack.Screen name="(tabs)" />
+            <Stack.Screen name="+not-found" />
+          </>
+        ) : (
+          <>
+            <Stack.Screen name="login" />
+            <Stack.Screen name="signup" />
+          </>
+        )}
       </Stack>
     </View>
+  );
+}
+
+export default function RootLayout() {
+  return (
+    <AuthProvider>
+      <Layout />
+    </AuthProvider>
   );
 }
 
 const styles = StyleSheet.create({
   root: {
     flex: 1,
-    backgroundColor: "#f9fafb", // Off-white/light gray background
+    backgroundColor: "#f9fafb",
+  },
+  center: {
+    justifyContent: "center",
+    alignItems: "center",
   },
 });

--- a/RewindApp/app/login.tsx
+++ b/RewindApp/app/login.tsx
@@ -1,0 +1,55 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, TouchableOpacity, StyleSheet } from 'react-native';
+import { signInWithEmailAndPassword } from 'firebase/auth';
+import { auth } from '../firebase';
+import { Link } from 'expo-router';
+
+export default function LoginScreen() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const handleLogin = async () => {
+    try {
+      await signInWithEmailAndPassword(auth, email.trim(), password);
+    } catch (e: any) {
+      setError(e.message);
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Rewind</Text>
+      {error ? <Text style={styles.error}>{error}</Text> : null}
+      <TextInput
+        style={styles.input}
+        placeholder="Email"
+        autoCapitalize="none"
+        keyboardType="email-address"
+        value={email}
+        onChangeText={setEmail}
+      />
+      <TextInput
+        style={styles.input}
+        placeholder="Password"
+        secureTextEntry
+        value={password}
+        onChangeText={setPassword}
+      />
+      <TouchableOpacity style={styles.button} onPress={handleLogin}>
+        <Text style={styles.buttonText}>Log In</Text>
+      </TouchableOpacity>
+      <Link href="/signup" style={styles.link}>Create account</Link>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', padding: 20, backgroundColor: '#fff' },
+  title: { fontSize: 32, fontWeight: 'bold', textAlign: 'center', marginBottom: 20 },
+  input: { borderWidth: 1, borderColor: '#ddd', borderRadius: 8, padding: 12, marginBottom: 12 },
+  button: { backgroundColor: '#fb5607', padding: 12, borderRadius: 8, alignItems: 'center' },
+  buttonText: { color: '#fff', fontWeight: 'bold' },
+  link: { marginTop: 16, color: '#fb5607', textAlign: 'center' },
+  error: { color: 'red', marginBottom: 12, textAlign: 'center' }
+});

--- a/RewindApp/app/signup.tsx
+++ b/RewindApp/app/signup.tsx
@@ -1,0 +1,55 @@
+import React, { useState } from 'react';
+import { View, Text, TextInput, TouchableOpacity, StyleSheet } from 'react-native';
+import { createUserWithEmailAndPassword } from 'firebase/auth';
+import { auth } from '../firebase';
+import { Link } from 'expo-router';
+
+export default function SignupScreen() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+
+  const handleSignup = async () => {
+    try {
+      await createUserWithEmailAndPassword(auth, email.trim(), password);
+    } catch (e: any) {
+      setError(e.message);
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Create Account</Text>
+      {error ? <Text style={styles.error}>{error}</Text> : null}
+      <TextInput
+        style={styles.input}
+        placeholder="Email"
+        autoCapitalize="none"
+        keyboardType="email-address"
+        value={email}
+        onChangeText={setEmail}
+      />
+      <TextInput
+        style={styles.input}
+        placeholder="Password"
+        secureTextEntry
+        value={password}
+        onChangeText={setPassword}
+      />
+      <TouchableOpacity style={styles.button} onPress={handleSignup}>
+        <Text style={styles.buttonText}>Sign Up</Text>
+      </TouchableOpacity>
+      <Link href="/login" style={styles.link}>Back to login</Link>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1, justifyContent: 'center', padding: 20, backgroundColor: '#fff' },
+  title: { fontSize: 32, fontWeight: 'bold', textAlign: 'center', marginBottom: 20 },
+  input: { borderWidth: 1, borderColor: '#ddd', borderRadius: 8, padding: 12, marginBottom: 12 },
+  button: { backgroundColor: '#fb5607', padding: 12, borderRadius: 8, alignItems: 'center' },
+  buttonText: { color: '#fff', fontWeight: 'bold' },
+  link: { marginTop: 16, color: '#fb5607', textAlign: 'center' },
+  error: { color: 'red', marginBottom: 12, textAlign: 'center' }
+});

--- a/RewindApp/context/AuthContext.tsx
+++ b/RewindApp/context/AuthContext.tsx
@@ -1,0 +1,31 @@
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import { User, onAuthStateChanged } from 'firebase/auth';
+import { auth } from '../firebase';
+
+interface AuthContextValue {
+  user: User | null;
+  loading: boolean;
+}
+
+const AuthContext = createContext<AuthContextValue>({ user: null, loading: true });
+
+export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
+  const [user, setUser] = useState<User | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const unsub = onAuthStateChanged(auth, (u) => {
+      setUser(u);
+      setLoading(false);
+    });
+    return unsub;
+  }, []);
+
+  return (
+    <AuthContext.Provider value={{ user, loading }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export const useAuth = () => useContext(AuthContext);

--- a/RewindApp/firebase.ts
+++ b/RewindApp/firebase.ts
@@ -1,0 +1,15 @@
+import { initializeApp } from 'firebase/app';
+import { getAuth } from 'firebase/auth';
+
+const firebaseConfig = {
+  apiKey: "AIzaSyAoeLl6IuaPaKXDSla6QC2Rc3cxAPvNWvs",
+  authDomain: "rewind-bb4eb.firebaseapp.com",
+  projectId: "rewind-bb4eb",
+  storageBucket: "rewind-bb4eb.firebasestorage.app",
+  messagingSenderId: "523214406021",
+  appId: "1:523214406021:web:6b96e4eb79eca4ac6a04ec"
+};
+
+const app = initializeApp(firebaseConfig);
+export const auth = getAuth(app);
+export default app;

--- a/RewindApp/package.json
+++ b/RewindApp/package.json
@@ -29,6 +29,7 @@
     "expo-symbols": "~0.4.5",
     "expo-system-ui": "~5.0.8",
     "expo-web-browser": "~14.1.6",
+    "firebase": "^9.6.11",
     "react": "19.0.0",
     "react-dom": "19.0.0",
     "react-native": "0.79.3",


### PR DESCRIPTION
## Summary
- add Firebase configuration
- create authentication context
- implement login and signup screens
- show login/signup when unauthenticated
- hook up logout button
- document Firebase auth in README

## Testing
- `npm run lint` *(fails: expo not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851e00eff808332a069ee724e3fb9a6